### PR TITLE
performance refactor + clinical significance flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ clinvar_checker-*.tar
 
 .elixir-tools/
 .elixir_ls/
+.lexical/

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ clinvar_checker-*.tar
 .elixir-tools/
 .elixir_ls/
 .lexical/
+
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Simple CLI tool to cross-check your raw 23andMe genetic data against the ClinVar
 - [x] Build the CLI tool
   - [x] Download the ClinVar database
   - [x] Cross-check user input 23andme data against the ClinVar database
-  - [ ] Optional flag for clinical significance
+  - [x] Optional flag for clinical significance
 - [ ] Make releases
+- [ ] Support different output formats (JSON, CSV, etc.)
 - [ ] Build out README - how to use, install, technical stuff, the algorithm for cross-checking
 - [ ] Research alternate alleles
 - [ ] Better aggregations based on likelihood of disease

--- a/lib/clinvar_checker.ex
+++ b/lib/clinvar_checker.ex
@@ -72,7 +72,7 @@ defmodule ClinvarChecker do
   def parse_clinvar_file(path) do
     clinvar_table =
       :ets.new(@clinvar_ets_table, [
-        :set,
+        :ordered_set,
         :public,
         :named_table,
         read_concurrency: true,

--- a/lib/clinvar_checker.ex
+++ b/lib/clinvar_checker.ex
@@ -84,9 +84,6 @@ defmodule ClinvarChecker do
     |> Flow.reduce(fn -> %{} end, fn {key, variant}, acc ->
       Map.put(acc, key, variant)
     end)
-    |> Flow.take_sort(100_000, fn {key1, _}, {key2, _} ->
-      key1 <= key2
-    end)
     |> Enum.to_list()
     |> List.flatten()
     |> Enum.into(%{})

--- a/lib/clinvar_checker.ex
+++ b/lib/clinvar_checker.ex
@@ -6,6 +6,9 @@ defmodule ClinvarChecker do
 
   @type args :: [memory_profile: boolean(), clinical_significance: String.t(), output: String.t()]
 
+  @clinvar_download "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz"
+  @clinvar_ets_table :clinvar_variants
+  @clinvar_file "tmp/clinvar.vcf"
   @clinical_significances MapSet.new([
                             "benign",
                             "likely_benign",
@@ -15,20 +18,26 @@ defmodule ClinvarChecker do
                             "uncertain",
                             "drug_response"
                           ])
-  @clinvar_download "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz"
-  @clinvar_file "tmp/clinvar.vcf"
   @default_output "tmp/variant_analysis_report.txt"
 
   def valid_clinical_significances(), do: @clinical_significances
+  defp stages, do: System.schedulers_online() * 2
 
   def run(input, args) do
     if File.exists?(@clinvar_file) do
       # Parse both datasets
-      personal_variants = parse_23andme_file(input)
-      clinvar_variants = parse_clinvar_file(@clinvar_file)
+      {time, personal_variants} = :timer.tc(fn -> parse_23andme_file(input) end)
+      IO.puts("23andMe data parsed in #{microseconds_to_seconds(time)} seconds")
+
+      {time, _} = :timer.tc(fn -> parse_clinvar_file(@clinvar_file) end)
+      IO.puts("ClinVar data parsed in #{microseconds_to_seconds(time)} seconds")
 
       # Find matches and generate report
-      matches = analyze_variants(personal_variants, clinvar_variants, args)
+      {time, matches} = :timer.tc(fn -> analyze_variants(personal_variants, args) end)
+
+      IO.puts(
+        "Analysis completed in #{microseconds_to_seconds(time)} seconds, found #{Enum.count(matches)} matches"
+      )
 
       # Generate report
       generate_report(matches, args[:output])
@@ -40,6 +49,8 @@ defmodule ClinvarChecker do
       System.halt(1)
     end
   end
+
+  defp microseconds_to_seconds(microseconds), do: microseconds / 1_000_000
 
   @spec download_clinvar_data() ::
           {:ok, file_name :: String.t()} | {:error, error_message :: String.t()}
@@ -58,45 +69,60 @@ defmodule ClinvarChecker do
     end
   end
 
-  @spec parse_clinvar_file(file_path :: String.t()) :: %{tuple() => map()}
+  @spec parse_clinvar_file(file_path :: String.t()) :: ets_table_name :: atom()
   def parse_clinvar_file(path) do
+    clinvar_table =
+      :ets.new(@clinvar_ets_table, [:set, :public, :named_table, read_concurrency: true])
+
     path
     |> File.stream!([], :line)
     |> Flow.from_enumerable(
-      max_demand: 1000,
-      stages: System.schedulers_online(),
-      window_trigger: Flow.Window.count(10_000),
+      max_demand: 4_000,
+      stages: stages(),
+      window_trigger: Flow.Window.count(40_000),
       window_period: :infinity
     )
-    |> Flow.partition(stages: System.schedulers_online())
-    |> Flow.reject(&String.starts_with?(&1, "#"))
+    |> Flow.partition(stages: stages())
     |> Flow.map(&parse_clinvar_line/1)
-    |> Flow.reject(&is_nil/1)
-    |> Flow.map(fn variant ->
-      key = {variant.chromosome, variant.position}
-      {key, variant}
+    |> Flow.map(fn
+      nil ->
+        nil
+
+      variant ->
+        key = {variant.chromosome, variant.position}
+        {key, variant}
     end)
     |> Flow.partition(
-      key: fn {key, _variant} ->
-        :erlang.phash2(elem(key, 0), System.schedulers_online())
-      end
+      key: fn
+        {key, _variant} ->
+          :erlang.phash2(elem(key, 0), stages())
+
+        val ->
+          :erlang.phash2(val, stages())
+      end,
+      stages: stages()
     )
-    |> Flow.reduce(fn -> %{} end, fn {key, variant}, acc ->
-      Map.put(acc, key, variant)
+    |> Flow.map(fn
+      {key, variant} -> :ets.insert(clinvar_table, {key, variant})
+      _ -> :ok
     end)
     |> Enum.to_list()
-    |> List.flatten()
-    |> Enum.into(%{})
+
+    @clinvar_ets_table
   end
+
+  defp parse_clinvar_line("#" <> _rest), do: nil
 
   defp parse_clinvar_line(line) do
     with [chrom, pos, _id, ref, alt, _qual, _filter, info] <-
            :binary.split(line, "\t", [:global]),
-         {position, _} <- Integer.parse(pos) do
+         {position, _} <-
+           Integer.parse(pos) do
       parsed_info = parse_clinvar_info(info)
+      normalized_chromosme = normalize_chromosome(chrom)
 
       %{
-        chromosome: normalize_chromosome(chrom),
+        chromosome: normalized_chromosme,
         position: position,
         reference: ref,
         alternate: alt,
@@ -141,35 +167,40 @@ defmodule ClinvarChecker do
       path
       |> File.stream!([], :line)
       |> Flow.from_enumerable(
-        max_demand: 1000,
-        stages: System.schedulers_online(),
-        window_trigger: Flow.Window.count(10_000),
+        max_demand: 4_000,
+        stages: stages(),
+        window_trigger: Flow.Window.count(40_000),
         window_period: :infinity
       )
       |> Flow.partition(stages: System.schedulers_online())
-      |> Flow.reject(&String.starts_with?(&1, "#"))
       |> Flow.map(&parse_23andme_line/1)
-      |> Flow.reject(&is_nil/1)
-      |> Flow.map(fn variant ->
-        key = {variant.chromosome, variant.position}
-        {key, variant}
+      |> Flow.map(fn
+        nil ->
+          nil
+
+        variant ->
+          key = {variant.chromosome, variant.position}
+          {key, variant}
       end)
       |> Flow.partition(
-        key: fn {key, _variant} ->
-          :erlang.phash2(elem(key, 0), System.schedulers_online())
-        end
+        key: fn
+          {key, _variant} -> :erlang.phash2(elem(key, 0), stages())
+          val -> :erlang.phash2(val, stages())
+        end,
+        stages: stages()
       )
-      |> Flow.reduce(fn -> %{} end, fn {key, variant}, acc ->
-        Map.put(acc, key, variant)
+      |> Flow.reduce(fn -> %{} end, fn
+        {key, variant}, acc -> Map.put(acc, key, variant)
+        _val, acc -> acc
       end)
-      |> Enum.to_list()
-      |> List.flatten()
       |> Enum.into(%{})
     else
       IO.puts("Error: 23andMe data file not found. Please use `clinvar-checker help` for help.\n")
       System.halt(1)
     end
   end
+
+  defp parse_23andme_line("#" <> _), do: nil
 
   defp parse_23andme_line(line) do
     with [rsid, chromosome, position, genotype] <- :binary.split(line, "\t", [:global]) do
@@ -187,45 +218,10 @@ defmodule ClinvarChecker do
   defp normalize_chromosome("MT"), do: "M"
   defp normalize_chromosome(chrom), do: chrom
 
-  # def analyze_variants(personal_data, clinvar_data, args) do
-  #   personal_data
-  #   |> Map.keys()
-  #   |> Enum.reduce([], fn key, matches ->
-  #     case Map.get(clinvar_data, key) do
-  #       nil ->
-  #         matches
-
-  #       clinvar_entry ->
-  #         if is_nil(args[:clinical_significance]) ||
-  #              MapSet.intersection(
-  #                clinvar_entry.processed_significances,
-  #                args[:clinical_significance]
-  #              )
-  #              |> MapSet.size() > 0 do
-  #           personal_variant = Map.get(personal_data, key)
-
-  #           [
-  #             %{
-  #               chromosome: elem(key, 0),
-  #               position: elem(key, 1),
-  #               rsid: personal_variant.rsid,
-  #               genotype: personal_variant.genotype,
-  #               clinical_significance: clinvar_entry.clinical_significance,
-  #               condition: clinvar_entry.condition
-  #             }
-  #             | matches
-  #           ]
-  #         else
-  #           matches
-  #         end
-  #     end
-  #   end)
-  # end
-
-  def analyze_variants(personal_data, clinvar_data, args) do
+  def analyze_variants(personal_data, args) do
     personal_data
     |> Map.keys()
-    |> Stream.map(fn key -> {key, Map.get(clinvar_data, key)} end)
+    |> Stream.map(fn key -> {key, fetch_clinvar_variant(key)} end)
     |> Stream.reject(fn {_key, clinvar_entry} -> is_nil(clinvar_entry) end)
     |> Stream.filter(&matches_significance?(&1, args[:clinical_significance]))
     |> Enum.map(fn {key, clinvar_entry} ->
@@ -240,6 +236,13 @@ defmodule ClinvarChecker do
         condition: clinvar_entry.condition
       }
     end)
+  end
+
+  defp fetch_clinvar_variant(key) do
+    case :ets.lookup(@clinvar_ets_table, key) do
+      [] -> nil
+      [{_key, clinvar_entry}] -> clinvar_entry
+    end
   end
 
   defp matches_significance?({_key, _clinvar_entry}, nil), do: true

--- a/lib/clinvar_checker/cli.ex
+++ b/lib/clinvar_checker/cli.ex
@@ -6,17 +6,20 @@ defmodule ClinvarChecker.Cli do
   """
   @spec main([String.t(), ...]) :: any()
   def main(args) do
-    args
-    |> sanitize_args()
-    |> parse_args()
-    |> then(fn args ->
-      if Mix.env() == :dev do
-        IO.inspect(args, label: "Parsed command and args")
-      else
-        args
-      end
+    ClinvarChecker.MemoryProfiler.profile(fn ->
+      args
+      |> sanitize_args()
+      |> parse_args()
+      |> validate_args()
+      |> then(fn args ->
+        if Mix.env() == :dev do
+          IO.inspect(args, label: "Parsed command and args")
+        else
+          args
+        end
+      end)
+      |> parse_command()
     end)
-    |> parse_command()
   end
 
   def parse_command({["check", input | _cmd], args}) do
@@ -67,6 +70,27 @@ defmodule ClinvarChecker.Cli do
       )
 
     {command, args}
+  end
+
+  defp validate_args({command, args}) do
+    case Keyword.get(args, :clinical_significance) do
+      nil ->
+        {command, args}
+
+      clinical_significance ->
+        parsed_cs = clinical_significance |> String.split(",") |> MapSet.new()
+        cs_diff = MapSet.difference(parsed_cs, ClinvarChecker.valid_clinical_significances())
+
+        if MapSet.size(cs_diff) > 0 do
+          IO.puts(
+            "Error: Invalid clinical significance(s) provided: #{inspect(cs_diff |> MapSet.to_list())}"
+          )
+
+          System.halt()
+        else
+          {command, Keyword.put(args, :clinical_significance, parsed_cs)}
+        end
+    end
   end
 
   defp sanitize_args(args) do

--- a/lib/clinvar_checker/cli.ex
+++ b/lib/clinvar_checker/cli.ex
@@ -23,9 +23,7 @@ defmodule ClinvarChecker.Cli do
   end
 
   def parse_command({["check", input | _cmd], args}) do
-    {:ok, count_matches} = ClinvarChecker.run(input, args)
-
-    IO.puts("Analysis complete. Found #{count_matches} matches.\n")
+    {:ok, _count_matches} = ClinvarChecker.run(input, args)
   end
 
   def parse_command({["download" | _cmd], _args}) do

--- a/lib/clinvar_checker/cli.ex
+++ b/lib/clinvar_checker/cli.ex
@@ -6,20 +6,18 @@ defmodule ClinvarChecker.Cli do
   """
   @spec main([String.t(), ...]) :: any()
   def main(args) do
-    ClinvarChecker.MemoryProfiler.profile(fn ->
-      args
-      |> sanitize_args()
-      |> parse_args()
-      |> validate_args()
-      |> then(fn args ->
-        if Mix.env() == :dev do
-          IO.inspect(args, label: "Parsed command and args")
-        else
-          args
-        end
-      end)
-      |> parse_command()
+    args
+    |> sanitize_args()
+    |> parse_args()
+    |> validate_args()
+    |> then(fn args ->
+      if Mix.env() == :dev do
+        IO.inspect(args, label: "Parsed command and args")
+      else
+        args
+      end
     end)
+    |> parse_command()
   end
 
   def parse_command({["check", input | _cmd], args}) do

--- a/lib/clinvar_checker/memory_profiler.ex
+++ b/lib/clinvar_checker/memory_profiler.ex
@@ -1,5 +1,5 @@
 defmodule ClinvarChecker.MemoryProfiler do
-  require Logger
+  # require Logger
 
   @spec profile((-> any())) :: any()
   def profile(func) do
@@ -14,7 +14,7 @@ defmodule ClinvarChecker.MemoryProfiler do
         {type, after_bytes - initial_memory[type]}
       end
 
-    Logger.info("""
+    IO.puts("""
     Memory Usage:
     Total: #{Sizeable.filesize(memory_diff[:total])}
     Processes: #{Sizeable.filesize(memory_diff[:processes])}

--- a/lib/clinvar_checker/memory_profiler.ex
+++ b/lib/clinvar_checker/memory_profiler.ex
@@ -1,5 +1,5 @@
 defmodule ClinvarChecker.MemoryProfiler do
-  # require Logger
+  require Logger
 
   @spec profile((-> any())) :: any()
   def profile(func) do
@@ -14,7 +14,7 @@ defmodule ClinvarChecker.MemoryProfiler do
         {type, after_bytes - initial_memory[type]}
       end
 
-    IO.puts("""
+    Logger.info("""
     Memory Usage:
     Total: #{Sizeable.filesize(memory_diff[:total])}
     Processes: #{Sizeable.filesize(memory_diff[:processes])}


### PR DESCRIPTION
## General Notes
- Adds new optional flag `--clinical-signficance` to only return variant matches that explicitly match the listed clinical significances
- Big performance upgrade for how 23andMe and ClinVar data is loaded, stored and analyzed. Locally saw times increase by >70%

## Technical Notes
- ClinVar data is now loaded into an `:ets` table. Concurrent reads/writes are enabled. Since we're doing partial matching for selects I used the `:ordered_set` table option
  - Multi-nucleotide variants (MNVs) are dropped - because of the format of the 23andMe data we can't confidently check for these variants
- 23andMe data is loaded into a list instead of a map
  - Drops "no-call" genotypes (e.g. "--")
- With new steps in analyze / new data types, upgraded the analyze function to run as a stream
- Tweaked `:flow` configuration - dynamic stages for partitions, bumped `max_demand` and `window_trigger`
- Got a bit smarter with how I'm using `:flow`:
  - For the most part removed `reject` and `filter` calls and opted for a pass through approach where invalid or missing entries are represented as `nil` and just get passed through the pipeline, then get ignored at each step through function head pattern matching 
  - Through combination of above, was able to drop unnecessary `Enum`s and `List` calls