### PR TITLE
updates logic to no longer return heterozygous variants with novel alts

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ClinvarChecker.MixProject do
   def project do
     [
       app: :clinvar_checker,
-      version: "1.0.1",
+      version: "1.1.0",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
`TLDR; Updated logic to remove potential false positives.`

Previously, homozygous variants and heterozygous matches (including those with novel alternates) were returned as positive matches. This updates the search logic to only look for homozygous variants and heterozygous matches with matching alt/ref. 

