### PR TITLE
simplify flow pipelines + improve performance

### DIFF
--- a/lib/clinvar_checker.ex
+++ b/lib/clinvar_checker.ex
@@ -167,21 +167,7 @@ defmodule ClinvarChecker do
       |> File.stream!([], :line)
       |> Flow.from_enumerable(max_demand: 4_000, stages: stages())
       |> Flow.map(&parse_23andme_line/1)
-      |> Flow.map(fn
-        nil ->
-          nil
-
-        genotype_call ->
-          {genotype_call.chromosome, genotype_call.position, genotype_call.genotype,
-           genotype_call.rsid}
-      end)
-      |> Flow.partition(
-        key: fn
-          {chrom, pos, genotype, _rsid} -> :erlang.phash2({chrom, pos, genotype}, stages())
-          val -> :erlang.phash2(val, stages())
-        end,
-        stages: stages()
-      )
+      |> Flow.partition()
       |> Flow.reduce(fn -> [] end, fn
         {_chrom, _pos, _genotype, _rsid} = call, acc -> [call | acc]
         _val, acc -> acc
@@ -202,12 +188,8 @@ defmodule ClinvarChecker do
       if trimmed_genotype == "--" do
         nil
       else
-        %{
-          rsid: rsid,
-          chromosome: normalize_chromosome(chromosome),
-          position: String.to_integer(position),
-          genotype: String.trim(genotype)
-        }
+        {normalize_chromosome(chromosome), String.to_integer(position), String.trim(genotype),
+         rsid}
       end
     else
       _ -> nil

--- a/lib/clinvar_checker.ex
+++ b/lib/clinvar_checker.ex
@@ -87,7 +87,6 @@ defmodule ClinvarChecker do
       window_trigger: Flow.Window.count(40_000),
       window_period: :infinity
     )
-    |> Flow.partition(stages: stages())
     |> Flow.map(&parse_clinvar_line/1)
     |> Flow.map(fn
       nil ->
@@ -182,7 +181,6 @@ defmodule ClinvarChecker do
         window_trigger: Flow.Window.count(40_000),
         window_period: :infinity
       )
-      |> Flow.partition(stages: System.schedulers_online())
       |> Flow.map(&parse_23andme_line/1)
       |> Flow.map(fn
         nil ->

--- a/lib/clinvar_checker.ex
+++ b/lib/clinvar_checker.ex
@@ -83,16 +83,7 @@ defmodule ClinvarChecker do
     |> File.stream!([], :line)
     |> Flow.from_enumerable(max_demand: 4_000, stages: stages())
     |> Flow.map(&parse_clinvar_line/1)
-    |> Flow.map(fn
-      nil ->
-        nil
-
-      variant ->
-        key =
-          {variant.chromosome, variant.position, variant.reference, variant.alternate}
-
-        {key, variant}
-    end)
+    |> Flow.map(&make_clinvar_key/1)
     |> Flow.partition(
       key: fn
         {key, _variant} ->
@@ -163,6 +154,15 @@ defmodule ClinvarChecker do
       processed_significances: processed_significances,
       condition: Map.get(info_map, "CLNDN", "unknown")
     }
+  end
+
+  defp make_clinvar_key(nil), do: nil
+
+  defp make_clinvar_key(variant) do
+    key =
+      {variant.chromosome, variant.position, variant.reference, variant.alternate}
+
+    {key, variant}
   end
 
   @spec parse_23andme_file(file_path :: String.t()) :: %{tuple() => map()}

--- a/lib/clinvar_checker.ex
+++ b/lib/clinvar_checker.ex
@@ -21,7 +21,7 @@ defmodule ClinvarChecker do
   @default_output "tmp/variant_analysis_report.txt"
 
   def valid_clinical_significances(), do: @clinical_significances
-  defp stages, do: System.schedulers_online() * 2
+  defp stages, do: System.schedulers_online()
   defp microseconds_to_seconds(microseconds), do: microseconds / 1_000_000
 
   def run(input, args) do

--- a/lib/clinvar_checker.ex
+++ b/lib/clinvar_checker.ex
@@ -102,7 +102,7 @@ defmodule ClinvarChecker do
       _, _acc ->
         []
     end)
-    |> Enum.to_list()
+    |> Flow.run()
 
     @clinvar_ets_table
   end

--- a/lib/clinvar_checker.ex
+++ b/lib/clinvar_checker.ex
@@ -81,12 +81,7 @@ defmodule ClinvarChecker do
 
     path
     |> File.stream!([], :line)
-    |> Flow.from_enumerable(
-      max_demand: 4_000,
-      stages: stages(),
-      window_trigger: Flow.Window.count(40_000),
-      window_period: :infinity
-    )
+    |> Flow.from_enumerable(max_demand: 4_000, stages: stages())
     |> Flow.map(&parse_clinvar_line/1)
     |> Flow.map(fn
       nil ->
@@ -175,12 +170,7 @@ defmodule ClinvarChecker do
     if File.exists?(path) do
       path
       |> File.stream!([], :line)
-      |> Flow.from_enumerable(
-        max_demand: 4_000,
-        stages: stages(),
-        window_trigger: Flow.Window.count(40_000),
-        window_period: :infinity
-      )
+      |> Flow.from_enumerable(max_demand: 4_000, stages: stages())
       |> Flow.map(&parse_23andme_line/1)
       |> Flow.map(fn
         nil ->

--- a/lib/clinvar_checker.ex
+++ b/lib/clinvar_checker.ex
@@ -93,6 +93,7 @@ defmodule ClinvarChecker do
       end,
       stages: stages()
     )
+    # functionally acts like Flow.each/2 used to without accumulating results
     |> Flow.reduce(fn -> [] end, fn
       {key, variant}, _acc ->
         :ets.insert(clinvar_table, {key, variant})

--- a/lib/clinvar_checker.ex
+++ b/lib/clinvar_checker.ex
@@ -167,11 +167,7 @@ defmodule ClinvarChecker do
       |> File.stream!([], :line)
       |> Flow.from_enumerable(max_demand: 4_000, stages: stages())
       |> Flow.map(&parse_23andme_line/1)
-      |> Flow.partition()
-      |> Flow.reduce(fn -> [] end, fn
-        {_chrom, _pos, _genotype, _rsid} = call, acc -> [call | acc]
-        _val, acc -> acc
-      end)
+      |> Flow.reject(&is_nil/1)
       |> Enum.to_list()
     else
       IO.puts("Error: 23andMe data file not found. Please use `clinvar-checker help` for help.\n")

--- a/lib/clinvar_checker.ex
+++ b/lib/clinvar_checker.ex
@@ -83,7 +83,6 @@ defmodule ClinvarChecker do
     |> File.stream!([], :line)
     |> Flow.from_enumerable(max_demand: 4_000, stages: stages())
     |> Flow.map(&parse_clinvar_line/1)
-    |> Flow.map(&make_clinvar_key/1)
     |> Flow.partition(
       key: fn
         {key, _variant} ->
@@ -116,7 +115,7 @@ defmodule ClinvarChecker do
       parsed_info = parse_clinvar_info(info)
       normalized_chromosme = normalize_chromosome(chrom)
 
-      %{
+      variant = %{
         chromosome: normalized_chromosme,
         position: position,
         reference: ref,
@@ -125,6 +124,11 @@ defmodule ClinvarChecker do
         clinical_significance: parsed_info.clinical_significance,
         condition: parsed_info.condition
       }
+
+      key =
+        {variant.chromosome, variant.position, variant.reference, variant.alternate}
+
+      {key, variant}
     else
       _ -> nil
     end
@@ -154,15 +158,6 @@ defmodule ClinvarChecker do
       processed_significances: processed_significances,
       condition: Map.get(info_map, "CLNDN", "unknown")
     }
-  end
-
-  defp make_clinvar_key(nil), do: nil
-
-  defp make_clinvar_key(variant) do
-    key =
-      {variant.chromosome, variant.position, variant.reference, variant.alternate}
-
-    {key, variant}
   end
 
   @spec parse_23andme_file(file_path :: String.t()) :: %{tuple() => map()}

--- a/lib/clinvar_checker.ex
+++ b/lib/clinvar_checker.ex
@@ -93,9 +93,13 @@ defmodule ClinvarChecker do
       end,
       stages: stages()
     )
-    |> Flow.map(fn
-      {key, variant} -> :ets.insert(clinvar_table, {key, variant})
-      _ -> :ok
+    |> Flow.reduce(fn -> [] end, fn
+      {key, variant}, _acc ->
+        :ets.insert(clinvar_table, {key, variant})
+        []
+
+      _, _acc ->
+        []
     end)
     |> Enum.to_list()
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ClinvarChecker.MixProject do
   def project do
     [
       app: :clinvar_checker,
-      version: "1.1.0",
+      version: "1.2.0",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## Technical Improvements
- Simplified 23andMe data load pipeline by removing partition stages. Since all genotype data is unique it can all be processed in parallel and then just collect it into an enumerable in the last step. Saw load times increase ~40% locally for this step.
- Simplified ClinVar data load pipeline by removing redundant steps. Since we only care about the side effect of this pipeline (`:ets`) table, swapped final step from `Enum.map/2` to `Flow.reduce/3` + `Flow.run/1` which also decreased memory footprint since a large list of `:ok`s are no longer being returned. Also saw a slight speed improvement, ~12%, locally.